### PR TITLE
Fix missing component error / crash on loading xlsx

### DIFF
--- a/SimsigImporter/SimsigImporter.csproj
+++ b/SimsigImporter/SimsigImporter.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DocumentFormat.OpenXml, Version=2.15.0.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
-      <HintPath>packages\DocumentFormat.OpenXml.2.15.0\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
+      <HintPath>..\packages\DocumentFormat.OpenXml.2.15.0\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>


### PR DESCRIPTION
I'm far from a Visual Studio / C# expert - when I downloaded the project I could compile and run, but it would crash when opening an .xlsx or generating a template .xlsx, while complaining of a missing component. Reinstalling the DocumentFormat.OpenXML packages in SimSigImporter and SimSigImporterLibrary fixed the problem and resulted in this three-character change.

I've tested this by pulling this commit into a new directory and rebuilding from scratch - it ran first time and generated/loaded spreadsheets without crashing!