### PR TITLE
Fix 6 record origin destination operator notes

### DIFF
--- a/SimsigImporterLibrary/Models/Timetable.cs
+++ b/SimsigImporterLibrary/Models/Timetable.cs
@@ -24,7 +24,7 @@ namespace SimsigImporterLib.Models
         /// <summary>
         /// Gets or sets the display text for this working
         /// </summary>
-        public string Description { get; set; } = string.Empty;
+        public string Description { get; set; } = "$template";
 
         /// <summary>
         /// The departure time in seconds from midnight


### PR DESCRIPTION
I've extended the spreadsheet helper to find and retrieve data in these rows:
- Origin
- OriginTime
- Destination
- DestinationTime
- OperatorCode
- Notes

Times should be entered the same way as elsewhere on the spreadsheet.

I've also changed the default description for each working (/ timetable / train) to be `$template` rather than empty as this allows the train details to be displayed conveniently in the pop-up timetable etc.